### PR TITLE
FIX: Anonymous users should be able to display viewpoints.

### DIFF
--- a/_attachments/js/jquery.agorae.js
+++ b/_attachments/js/jquery.agorae.js
@@ -55,7 +55,7 @@
       bAsync = (typeof(options.async) != "boolean") ? false : options.async;
       processData = (typeof(options.processData) != "boolean") ? false : options.processData;
       dataType = (typeof(options.dataType) == "string") ? options.dataType : "json";
-      headers = options.anonymous? {} : {
+      headers = (options.anonymous || $.agorae.session.username===undefined)? {} : {
         Authorization: "Basic "
         + btoa($.agorae.session.username + ":" + $.agorae.session.password)
       };


### PR DESCRIPTION
I discovered a 401 error during main page display.

As an anonymous user, I could not load configured viewpoints.
