### PR TITLE
Modification du spec_helper et ajout de delete_item

### DIFF
--- a/spec/features/delete_item.rb
+++ b/spec/features/delete_item.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+feature 'Delete items' do
+
+  $a_title = a_string()
+
+  background do
+    pending 'stay updated about article lifecycle'
+    visit $home_page
+    click_on 'Se connecter'
+    log_in_as 'alice', 'lapinblanc'
+    click_on 'UV'
+    toggle_edit
+    click_on 'Items +'
+    fill_in 'Sans nom', :with => $a_title
+  end
+  
+  scenario 'To delete an item' do
+    pending 'stay updated about article lifecycle'
+    visit $home_page
+    click_on 'UV'
+    toggle_edit
+    click_del_sign_next_to $a_title
+    expect(page).not_to have_content $a_title
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ def click_plus_sign_next_to(list)
   find(".#{list}-list .add").click
 end
 
+def click_del_sign_next_to(list)
+  find(".#{list}-list .del").click
+end
+
 def click_last(list)
   find("##{list} li:last-child .editable").click
 end


### PR DESCRIPTION
Ajout de la fonction click_del_sign_next_to(list) dans le fichier spec_helper.rb qui servira au fichier delete_item.rb nouvellement créé.